### PR TITLE
removing forced watch on docpad ready

### DIFF
--- a/src/minicms.plugin.coffee
+++ b/src/minicms.plugin.coffee
@@ -34,13 +34,6 @@ module.exports = (BasePlugin) ->
             sanitize: require './utils/sanitize'
 
 
-        # When dopac is ready, force it to watch files
-        docpadReady: (opts) ->
-            @docpad.action 'watch', {}, (err) ->
-                if err then process.stderr.write ("#{err.message ? err}").trim()+"\n"
-                @docpad.log "Force watching file for minicms."
-
-
         # Server Extend
         # Used to add our own custom routes to the server before the docpad routes are added
         serverExtend: (opts) ->


### PR DESCRIPTION
This chokes current versions of DocPad even when running `docpad server`.

Fixes #19 
Credit to @SteveMcArthur
