### PR TITLE
Example project missing October from Date to Month name translations causes regeneration to fail

### DIFF
--- a/examples/blog/src/layouts/article.html.coffee
+++ b/examples/blog/src/layouts/article.html.coffee
@@ -2,7 +2,7 @@
 layout: page
 ###
 
-months = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'NOV', 'DEC']
+months = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC']
 
 article '.post', ->
 

--- a/examples/blog/src/layouts/home.html.coffee
+++ b/examples/blog/src/layouts/home.html.coffee
@@ -2,7 +2,7 @@
 layout: page
 ###
 
-months = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'NOV', 'DEC']
+months = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC']
 
 for item in @getArticles()
 


### PR DESCRIPTION
October missing from the month list causes the site to fail to generate if any Articles have a date in December as the index is out of range.
It also causes the wrong month to be listed in the example for the calendar icons for each post for the months October (maps to NOV) and November (maps to DEC).
